### PR TITLE
feat(mssql): move connection to client

### DIFF
--- a/internal/mssql/sqlclient.go
+++ b/internal/mssql/sqlclient.go
@@ -5,14 +5,15 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-	_ "github.com/microsoft/go-mssqldb"
 	"net/url"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	_ "github.com/microsoft/go-mssqldb"
 )
 
 type client struct {
-	connect func(ctx context.Context) (*sql.DB, error)
+	conn *sql.DB
 }
 
 func NewClient(host string, port int64, database string, username string, password string) SqlClient {
@@ -20,14 +21,17 @@ func NewClient(host string, port int64, database string, username string, passwo
 		port = 1433
 	}
 
-	c := client{
-		connect: func(ctx context.Context) (*sql.DB, error) {
-			connString := fmt.Sprintf("server=%s;user id=%s;password=%s;port=%d;database=%s", host, username, password, port, database)
-			conn, err := sql.Open("sqlserver", connString)
-			return conn, err
-		},
+	connString := fmt.Sprintf("server=%s;user id=%s;password=%s;port=%d;database=%s", host, username, password, port, database)
+	conn, err := sql.Open("sqlserver", connString)
+
+	if err != nil {
+		// TODO handle error
+		panic(err)
 	}
 
+	c := client{
+		conn: conn,
+	}
 	return c
 }
 
@@ -36,18 +40,12 @@ func (m client) GetUser(ctx context.Context, username string) (User, error) {
 		Id: username,
 	}
 
-	conn, err := m.connect(nil)
-	if err != nil {
-		return user, err
-	}
-	defer conn.Close()
-
-	cmd := `SELECT 
-    P.[name] AS id, 
+	cmd := `SELECT
+    P.[name] AS id,
     COALESCE(CONVERT(varchar(175), P.[sid],1), '') AS sid,
-    P.[name] AS name, 
+    P.[name] AS name,
     P.[type] AS type,
-    CASE WHEN P.[type] IN ('E', 'X') THEN 1 ELSE 0 END AS ext, 
+    CASE WHEN P.[type] IN ('E', 'X') THEN 1 ELSE 0 END AS ext,
     COALESCE(L.[name], '') AS login,
     COALESCE(P.[default_schema_name], '') AS default_schema_name
 FROM sys.database_principals P
@@ -55,9 +53,9 @@ LEFT JOIN sys.sql_logins L ON P.sid = L.sid
 WHERE P.[name] = @username`
 
 	tflog.Debug(ctx, fmt.Sprintf("Executing refresh query for username %s: command %s", username, cmd))
-	result := conn.QueryRowContext(ctx, cmd, sql.Named("username", username))
+	result := m.conn.QueryRowContext(ctx, cmd, sql.Named("username", username))
 
-	err = result.Scan(&user.Id, &user.Sid, &user.Username, &user.Type, &user.External, &user.Login, &user.DefaultSchema)
+	err := result.Scan(&user.Id, &user.Sid, &user.Username, &user.Type, &user.External, &user.Login, &user.DefaultSchema)
 	return user, err
 }
 
@@ -68,13 +66,7 @@ func (m client) CreateUser(ctx context.Context, create CreateUser) (User, error)
 		return user, err
 	}
 
-	conn, err := m.connect(nil)
-	if err != nil {
-		return user, err
-	}
-	defer conn.Close()
-
-	_, err = conn.ExecContext(ctx,
+	_, err = m.conn.ExecContext(ctx,
 		cmd,
 		args...,
 	)
@@ -174,16 +166,10 @@ func (m client) UpdateUser(ctx context.Context, update UpdateUser) (User, error)
 		cmdBuilder.WriteString(";\n")
 		cmdBuilder.WriteString("EXEC (@sql);")
 
-		conn, err := m.connect(nil)
-		if err != nil {
-			return User{}, err
-		}
-		defer conn.Close()
-
 		cmd := cmdBuilder.String()
 		tflog.Debug(ctx, fmt.Sprintf("Updating User %s: cmd: %s", update.Id, cmd))
 
-		_, err = conn.ExecContext(ctx,
+		_, err := m.conn.ExecContext(ctx,
 			cmd,
 			args...,
 		)
@@ -202,14 +188,8 @@ func (m client) DeleteUser(ctx context.Context, username string) error {
           SET @sql = 'IF EXISTS (SELECT 1 FROM [sys].[database_principals] WHERE [type] IN (''E'',''S'',''X'') AND [name] = ' + QUOTENAME(@p1, '''') + ') DROP USER ' + QUOTENAME(@p2);
           EXEC (@sql);`
 
-	conn, err := m.connect(nil)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
 	tflog.Debug(ctx, fmt.Sprintf("Deleting User %s: cmd: %s", username, cmd))
-	_, err = conn.ExecContext(ctx,
+	_, err := m.conn.ExecContext(ctx,
 		cmd,
 		username,
 		username,
@@ -260,14 +240,9 @@ WHERE r.type = 'R'
 AND R.name = @p1
 AND M.name = @p2
 `
-	conn, err := m.connect(nil)
-	if err != nil {
-		return roleMembership, err
-	}
-	defer conn.Close()
 
 	tflog.Debug(ctx, fmt.Sprintf("Reading Role Assignment role %s, member %s: cmd: %s", role, member, cmd))
-	result := conn.QueryRowContext(ctx,
+	result := m.conn.QueryRowContext(ctx,
 		cmd,
 		role,
 		member,
@@ -292,14 +267,8 @@ func (m client) AssignRole(ctx context.Context, role string, member string) (Rol
           SET @sql = 'ALTER ROLE ' + QUOTENAME(@p1) + ' ADD MEMBER ' + QUOTENAME(@p2);
           EXEC (@sql);`
 
-	conn, err := m.connect(nil)
-	if err != nil {
-		return roleMembership, err
-	}
-	defer conn.Close()
-
 	tflog.Debug(ctx, fmt.Sprintf("Adding Principal %s to role %s: cmd: %s", member, role, cmd))
-	_, err = conn.ExecContext(ctx,
+	_, err := m.conn.ExecContext(ctx,
 		cmd,
 		role,
 		member,
@@ -316,14 +285,8 @@ func (m client) UnassignRole(ctx context.Context, role string, principal string)
           SET @sql = 'ALTER ROLE ' + QUOTENAME(@p1) + ' DROP MEMBER ' + QUOTENAME(@p2);
           EXEC (@sql);`
 
-	conn, err := m.connect(nil)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
 	tflog.Debug(ctx, fmt.Sprintf("Removing Principal %s from role %s: cmd: %s", principal, role, cmd))
-	_, err = conn.ExecContext(ctx,
+	_, err := m.conn.ExecContext(ctx,
 		cmd,
 		role,
 		principal,

--- a/internal/mssql/sqlclient.go
+++ b/internal/mssql/sqlclient.go
@@ -3,7 +3,6 @@ package mssql
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -85,23 +84,23 @@ func buildCreateUser(create CreateUser) (string, []any, error) {
 	var args []any
 
 	if create.Login != "" && create.Password != "" {
-		return "", nil, errors.New(fmt.Sprintf("invalid user %s, login users may not have passwords", create.Username))
+		return "", nil, fmt.Errorf("invalid user %s, login users may not have passwords", create.Username)
 	}
 
 	if create.External && create.Password != "" {
-		return "", nil, errors.New(fmt.Sprintf("invalid user %s, external users may not have passwords", create.Username))
+		return "", nil, fmt.Errorf("invalid user %s, external users may not have passwords", create.Username)
 	}
 
 	if create.External && create.Login != "" {
-		return "", nil, errors.New(fmt.Sprintf("invalid user %s, external users must not have a login", create.Username))
+		return "", nil, fmt.Errorf("invalid user %s, external users must not have a login", create.Username)
 	}
 
 	if create.External && create.Sid != "" {
-		return "", nil, errors.New(fmt.Sprintf("invalid user %s, external users must not have a SID", create.Username))
+		return "", nil, fmt.Errorf("invalid user %s, external users must not have a SID", create.Username)
 	}
 
 	if create.DefaultSchema == "" {
-		return "", nil, errors.New(fmt.Sprintf("invalid user %s, default schema must be specified", create.Username))
+		return "", nil, fmt.Errorf("invalid user %s, default schema must be specified", create.Username)
 	}
 
 	cmdBuilder.WriteString("DECLARE @sql NVARCHAR(max);\n")

--- a/internal/provider/mssql_user_resource_test.go
+++ b/internal/provider/mssql_user_resource_test.go
@@ -4,9 +4,9 @@
 package provider
 
 import (
-	"fmt"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccMssqlUserResource(t *testing.T) {
@@ -52,10 +52,10 @@ func TestAccMssqlUserResource(t *testing.T) {
 }
 
 func testAccMssqlUserResourceConfig() string {
-	return fmt.Sprintf(`
+	return `
 resource "mssql_user" "test" {
   username = "testusername"
   password = "testpassword-meet-requirements1234@@@"
 }
-`)
+`
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -25,8 +26,7 @@ type MssqlProvider struct {
 	// version is set to the provider version on release, "dev" when the
 	// provider is built and ran locally, and "test" when running acceptance
 	// testing.
-	version      string
-	providerData core.ProviderData
+	version string
 }
 
 type SqlAuth struct {


### PR DESCRIPTION
## Intent

- Moving the initiation of the connection to the NewClient so we could re-use it later on
- A drawback of this is that we couldn't defer to close the connection after the operations have been completed but as https://pkg.go.dev/database/sql#Open stated:

> The returned [DB](https://pkg.go.dev/database/sql#DB) is safe for concurrent use by multiple goroutines and maintains its own pool of idle connections. Thus, the Open function should be called just once. It is rarely necessary to close a [DB](https://pkg.go.dev/database/sql#DB).