### PR TITLE
fix(buildCreateUser): Append space on FROM EXTERNAL PROVIDER for managed identity

### DIFF
--- a/internal/mssql/sqlclient.go
+++ b/internal/mssql/sqlclient.go
@@ -99,7 +99,7 @@ func buildCreateUser(create CreateUser) (string, []any, error) {
 
 	// Non Options
 	if create.External {
-		cmdBuilder.WriteString(" + ' FROM EXTERNAL PROVIDER'")
+		cmdBuilder.WriteString(" + ' FROM EXTERNAL PROVIDER '")
 	}
 
 	// Begin Options. Easy since we make DefaultSchema required

--- a/internal/mssql/sqlclient_test.go
+++ b/internal/mssql/sqlclient_test.go
@@ -52,7 +52,7 @@ func Test_buildCreateUser(t *testing.T) {
 				External:      true,
 				DefaultSchema: "dbo",
 			}},
-			want:  `DECLARE @sql NVARCHAR(max);SET @sql = 'CREATE USER ' + QUOTENAME(@username) + ' FROM EXTERNAL PROVIDER' + 'WITH ' + 'DEFAULT_SCHEMA = ' + QUOTENAME(@default_schema);EXEC (@sql);`,
+			want:  `DECLARE @sql NVARCHAR(max);SET @sql = 'CREATE USER ' + QUOTENAME(@username) + ' FROM EXTERNAL PROVIDER ' + 'WITH ' + 'DEFAULT_SCHEMA = ' + QUOTENAME(@default_schema);EXEC (@sql);`,
 			want1: []any{sql.Named("username", "bob@contoso.com"), sql.Named("default_schema", "dbo")},
 		},
 		{


### PR DESCRIPTION
Fix for https://github.com/vsabella/terraform-provider-mssql/issues/29, where we identified that statement assembly is broken if you're attempting to use managed-identity authentication (i.e. `FROM EXTERNAL PROVIDER`)