### PR TITLE
Added Azure AD auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,148 @@
-# Terraform Provider Scaffolding (Terraform Plugin Framework)
+# Terraform Provider for Microsoft SQL Server
 
-_This template repository is built on the [Terraform Plugin Framework](https://github.com/hashicorp/terraform-plugin-framework). The template repository built on the [Terraform Plugin SDK](https://github.com/hashicorp/terraform-plugin-sdk) can be found at [terraform-provider-scaffolding](https://github.com/hashicorp/terraform-provider-scaffolding). See [Which SDK Should I Use?](https://developer.hashicorp.com/terraform/plugin/framework-benefits) in the Terraform documentation for additional information._
+This provider allows you to manage Microsoft SQL Server resources using Terraform. It provides a way to interact with SQL Server databases, tables, and other database objects as infrastructure as code.
 
-This repository is a *template* for a [Terraform](https://www.terraform.io) provider. It is intended as a starting point for creating Terraform providers, containing:
+## Features
 
-- A resource and a data source (`internal/provider/`),
-- Examples (`examples/`) and generated documentation (`docs/`),
-- Miscellaneous meta files.
-
-These files contain boilerplate code that you will need to edit to create your own Terraform provider. Tutorials for creating Terraform providers can be found on the [HashiCorp Developer](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework) platform. _Terraform Plugin Framework specific guides are titled accordingly._
-
-Please see the [GitHub template repository documentation](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template) for how to create a new repository from this template on GitHub.
-
-Once you've written your provider, you'll want to [publish it on the Terraform Registry](https://developer.hashicorp.com/terraform/registry/providers/publishing) so that others can use it.
+- Manage SQL Server databases and their configurations
+- Create and manage database tables
+- Configure database users and permissions
+- Support for SQL Server authentication
 
 ## Requirements
 
 - [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.0
 - [Go](https://golang.org/doc/install) >= 1.21
+- Microsoft SQL Server instance (local or remote)
 
-## Building The Provider
+## Installation
 
-1. Clone the repository
-1. Enter the repository directory
-1. Build the provider using the Go `install` command:
+### Using Terraform Registry
 
+Add the following to your Terraform configuration:
+
+```hcl
+terraform {
+  required_providers {
+    mssql = {
+      source = "vsabella/mssql"
+      version = "~> 0.1.0"  # Replace with the latest version
+    }
+  }
+}
+```
+
+### Building from Source
+
+1. Clone the repository:
+```shell
+git clone https://github.com/vsabella/terraform-provider-mssql.git
+cd terraform-provider-mssql
+```
+
+2. Build the provider:
 ```shell
 go install
 ```
 
-## Adding Dependencies
+## Provider Configuration
 
-This provider uses [Go modules](https://github.com/golang/go/wiki/Modules).
-Please see the Go documentation for the most up to date information about using Go modules.
+Configure the provider in your Terraform configuration:
 
-To add a new dependency `github.com/author/dependency` to your Terraform provider:
-
-```shell
-go get github.com/author/dependency
-go mod tidy
+```hcl
+provider "mssql" {
+  host     = "your-sql-server-host"
+  port     = 1433
+  database = "your-database-name"
+  sql_auth {
+    username = "your-username"
+    password = "your-password"
+  }
+}
 ```
 
-Then commit the changes to `go.mod` and `go.sum`.
+### Provider Arguments
 
-## Using the provider
+- `host` - (Required) The hostname or IP address of the SQL Server instance
+- `port` - (Optional) The port number for the SQL Server instance (default: 1433)
+- `database` - (Required) The name of the database to connect to
+- `sql_auth` - (Optional) SQL Server authentication block. When provided, SQL authentication will be used when connecting.
+  - `username` - (Required when using SQL authentication) The SQL Server username
+  - `password` - (Required when using SQL authentication) The SQL Server password
 
-Fill this in for each provider
+## Resources
 
-## Developing the Provider
+### Database
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (see [Requirements](#requirements) above).
+```hcl
+resource "mssql_database" "example" {
+  name = "example_database"
+  collation = "SQL_Latin1_General_CP1_CI_AS"
+}
+```
 
-To compile the provider, run `go install`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
+### Table
 
-To generate or update documentation, run `go generate`.
+```hcl
+resource "mssql_table" "example" {
+  database_id = mssql_database.example.id
+  name = "example_table"
+  schema = "dbo"
+  columns = [
+    {
+      name = "id"
+      type = "int"
+      nullable = false
+    },
+    {
+      name = "name"
+      type = "varchar"
+      length = 255
+      nullable = true
+    }
+  ]
+}
+```
 
-In order to run the full suite of Acceptance tests, run `make testacc`.
+## Data Sources
 
-*Note:* Acceptance tests require modern docker/docker-compose. They creates an empty local SQL DB container to run the tests.  See [ci/run_acceptance.sh](ci/run_acceptance.sh)
+### Database
+
+```hcl
+data "mssql_database" "example" {
+  name = "example_database"
+}
+```
+
+## Development
+
+### Building the Provider
+
+To compile the provider, run:
+```shell
+go install
+```
+
+### Running Tests
+
+To run the full suite of acceptance tests:
+```shell
+make testacc
+```
+
+Note: Acceptance tests require Docker and docker-compose. They create an empty local SQL Server container to run the tests. See [ci/run_acceptance.sh](ci/run_acceptance.sh) for more details.
+
+### Generating Documentation
+
+To generate or update documentation:
+```shell
+go generate
+```
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+This project is licensed under the MPL-2.0 License - see the [LICENSE](LICENSE) file for details.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/vsabella/terraform-provider-mssql
 go 1.22
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.1
 	github.com/hashicorp/terraform-plugin-docs v0.18.0
 	github.com/hashicorp/terraform-plugin-framework v1.8.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
@@ -12,6 +13,9 @@ require (
 )
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.1 // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.1 // indirect
 	github.com/Kunde21/markdownfmt/v3 v3.1.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
@@ -23,6 +27,7 @@ require (
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/fatih/color v1.16.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.0 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
@@ -49,6 +54,7 @@ require (
 	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
@@ -58,6 +64,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
@@ -78,5 +85,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240509183442-62759503f434 // indirect
 	google.golang.org/grpc v1.63.2 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
-	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
+github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
@@ -252,6 +254,7 @@ golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
@@ -291,7 +294,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/mssql/sqlclient.go
+++ b/internal/mssql/sqlclient.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	_ "github.com/microsoft/go-mssqldb"
 )
@@ -32,6 +34,36 @@ func NewClient(host string, port int64, database string, username string, passwo
 		conn: conn,
 	}
 	return c
+}
+
+// NewAzureADClient creates a new SQL client authenticated via Azure AD
+func NewAzureADClient(host string, port int64, database string) (SqlClient, error) {
+	if port <= 0 {
+		port = 1433
+	}
+
+	// Set up Managed Identity credential using system-assigned identity
+	cred, err := azidentity.NewManagedIdentityCredential(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get managed identity credential: %v", err)
+	}
+
+	// Get the token for SQL Database authentication
+	token, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{
+		Scopes: []string{"https://database.windows.net/.default"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get token: %v", err)
+	}
+
+	// Prepare the connection string with the acquired token
+	connString := fmt.Sprintf("server=%s;database=%s;authentication=ActiveDirectoryMsi;access token=%s", host, database, token.Token)
+	conn, err := sql.Open("sqlserver", connString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to SQL Server: %v", err)
+	}
+
+	return &client{conn: conn}, nil
 }
 
 func (m client) GetUser(ctx context.Context, username string) (User, error) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/function"
@@ -35,10 +36,11 @@ type SqlAuth struct {
 }
 
 type MssqlProviderModel struct {
-	Host     types.String `tfsdk:"host"`
-	Port     types.Int64  `tfsdk:"port"`
-	Database types.String `tfsdk:"database"`
-	SqlAuth  *SqlAuth     `tfsdk:"sql_auth"`
+	Host        types.String `tfsdk:"host"`
+	Port        types.Int64  `tfsdk:"port"`
+	Database    types.String `tfsdk:"database"`
+	SqlAuth     *SqlAuth     `tfsdk:"sql_auth"`
+	AzureADAuth types.Bool   `tfsdk:"azure_ad_auth"`
 }
 
 func (p *MssqlProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -76,6 +78,10 @@ func (p *MssqlProvider) Schema(ctx context.Context, req provider.SchemaRequest, 
 					},
 				},
 			},
+			"azure_ad_auth": schema.BoolAttribute{
+				Description: "When true, Azure AD authentication will be used when connecting.",
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -112,13 +118,50 @@ func (p *MssqlProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		)
 	}
 
+	if data.SqlAuth == nil && !data.AzureADAuth.ValueBool() {
+		resp.Diagnostics.AddError(
+			"Missing Authentication",
+			"Either sql_auth or azure_ad_auth must be provided.",
+		)
+	}
+
+	if data.SqlAuth != nil && data.AzureADAuth.ValueBool() {
+		resp.Diagnostics.AddError(
+			"Multiple Authentication Methods",
+			"Only one authentication method (sql_auth or azure_ad_auth) can be provided.",
+		)
+	}
+
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	// Create Client Context
-	client := &core.ProviderData{
-		Client: mssql.NewClient(data.Host.ValueString(), data.Port.ValueInt64(), data.Database.ValueString(), data.SqlAuth.Username.ValueString(), data.SqlAuth.Password.ValueString()),
+	var client *core.ProviderData
+	if data.SqlAuth != nil {
+		client = &core.ProviderData{
+			Client: mssql.NewClient(data.Host.ValueString(), data.Port.ValueInt64(), data.Database.ValueString(), data.SqlAuth.Username.ValueString(), data.SqlAuth.Password.ValueString()),
+		}
+	} else if data.AzureADAuth.ValueBool() {
+		var db mssql.SqlClient
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					resp.Diagnostics.AddError("Failed to create Azure AD client", fmt.Sprintf("%v", r))
+				}
+			}()
+			var err error
+			db, err = mssql.NewAzureADClient(data.Host.ValueString(), data.Port.ValueInt64(), data.Database.ValueString())
+			if err != nil {
+				resp.Diagnostics.AddError("Failed to create Azure AD client", err.Error())
+			}
+		}()
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		client = &core.ProviderData{
+			Client: db,
+		}
 	}
 
 	resp.DataSourceData = client


### PR DESCRIPTION
Currently the provider only accepts an admin username and password that are use to authenticate the AzureSQL server. However, when using managed identities to create mssql_users, the server must be authenticated using an Azure AD account. The SQL server itself already has a system-assigned managed identity which we can use to authenticate automatically.

Instead of defining the `sql_auth` input during provider initialization, the user would simply set `azure_ad_auth = true`.
This will:

1. Check that only one of the options is selected: either `sql_auth` defined OR `azure_ad_auth == true` but not simultaneously.
2. Use the newly added `NewAzureADClient` function to:
          a. Set up Managed Identity credential using system-assigned identity
          b. Get the token for SQL Database authentication
          c. Prepare the connection string with the acquired token
          d. Open a connection
