### PR TITLE
feat: add login sid and auto-import

### DIFF
--- a/docs/resources/login.md
+++ b/docs/resources/login.md
@@ -24,8 +24,10 @@ Manages a SQL Server login (server-level principal). Use this resource to create
 
 ### Optional
 
+- `auto_import` (Boolean) If true, and the login already exists, adopt it into state instead of failing create. Existing logins are not modified during adoption.
 - `default_database` (String) Default database for the login. Defaults to `master`.
 - `default_language` (String) Default language for the login. If not specified, uses the server default.
+- `sid` (String) SID for the login, as a hex string (e.g., `0x010500000000000515000000...`). Changing this forces a new resource to be created.
 
 ### Read-Only
 

--- a/docs/resources/login.md
+++ b/docs/resources/login.md
@@ -3,12 +3,12 @@
 page_title: "mssql_login Resource - mssql"
 subcategory: ""
 description: |-
-  Manages a SQL Server login (server-level principal). Use this resource to create SQL authentication logins that can then be mapped to database users.
+  Manages a SQL Server login (server-level principal). Use this resource to create or adopt SQL authentication logins that can then be mapped to database users.
 ---
 
 # mssql_login (Resource)
 
-Manages a SQL Server login (server-level principal). Use this resource to create SQL authentication logins that can then be mapped to database users.
+Manages a SQL Server login (server-level principal). Use this resource to create or adopt SQL authentication logins that can then be mapped to database users.
 
 
 
@@ -24,10 +24,10 @@ Manages a SQL Server login (server-level principal). Use this resource to create
 
 ### Optional
 
-- `auto_import` (Boolean) If true, and the login already exists, adopt it into state instead of failing create. Existing logins are not modified during adoption.
+- `auto_import` (Boolean) When true, if the login already exists, adopt it into state instead of failing create. Existing logins are not modified during adoption.
 - `default_database` (String) Default database for the login. Defaults to `master`.
 - `default_language` (String) Default language for the login. If not specified, uses the server default.
-- `sid` (String) SID for the login, as a hex string (e.g., `0x010500000000000515000000...`). Changing this forces a new resource to be created.
+- `sid` (String) Login SID as a hex string (for example `0x010500000000000515000000...`). Changing this forces a new resource to be created.
 
 ### Read-Only
 

--- a/internal/mssql/interfaces.go
+++ b/internal/mssql/interfaces.go
@@ -140,6 +140,7 @@ type Login struct {
 	DefaultDatabase string
 	DefaultLanguage string
 	IsDisabled      bool
+	Sid             string
 }
 
 // CreateLogin contains parameters for creating a new login.
@@ -148,6 +149,7 @@ type CreateLogin struct {
 	Password        string
 	DefaultDatabase string
 	DefaultLanguage string
+	Sid             string
 }
 
 // UpdateLogin contains parameters for updating an existing login.

--- a/internal/provider/mssql_login_resource.go
+++ b/internal/provider/mssql_login_resource.go
@@ -49,7 +49,7 @@ func (r *MssqlLoginResource) Metadata(ctx context.Context, req resource.Metadata
 
 func (r *MssqlLoginResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manages a SQL Server login (server-level principal). Use this resource to create SQL authentication logins that can then be mapped to database users.",
+		MarkdownDescription: "Manages a SQL Server login (server-level principal). Use this resource to create or adopt SQL authentication logins that can then be mapped to database users.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -84,7 +84,7 @@ func (r *MssqlLoginResource) Schema(ctx context.Context, req resource.SchemaRequ
 				Computed:            true,
 			},
 			"sid": schema.StringAttribute{
-				MarkdownDescription: "SID for the login, as a hex string (e.g., `0x010500000000000515000000...`). Changing this forces a new resource to be created.",
+				MarkdownDescription: "Login SID as a hex string (for example `0x010500000000000515000000...`). Changing this forces a new resource to be created.",
 				Optional:            true,
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
@@ -93,7 +93,7 @@ func (r *MssqlLoginResource) Schema(ctx context.Context, req resource.SchemaRequ
 				},
 			},
 			"auto_import": schema.BoolAttribute{
-				MarkdownDescription: "If true, and the login already exists, adopt it into state instead of failing create. Existing logins are not modified during adoption.",
+				MarkdownDescription: "When true, if the login already exists, adopt it into state instead of failing create. Existing logins are not modified during adoption.",
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
@@ -135,6 +135,7 @@ func (r *MssqlLoginResource) Create(ctx context.Context, req resource.CreateRequ
 		Sid:             data.Sid.ValueString(),
 	}
 
+	// Auto-import (adopt) existing login instead of failing create.
 	if data.AutoImport.ValueBool() {
 		login, err := r.ctx.Client.GetLogin(ctx, create.Name)
 		if err == nil {

--- a/internal/provider/mssql_login_resource.go
+++ b/internal/provider/mssql_login_resource.go
@@ -295,6 +295,7 @@ func (r *MssqlLoginResource) ImportState(ctx context.Context, req resource.Impor
 	if login.Sid != "" {
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("sid"), login.Sid)...)
 	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("auto_import"), false)...)
 
 	// Password cannot be imported - user will need to set it
 	resp.Diagnostics.AddWarning(


### PR DESCRIPTION
## Summary
- Add `sid` to `mssql_login` for deterministic login SIDs.
- Add `auto_import` to adopt existing logins on create without modifying them.
- Add SID validation plus unit and ACC coverage (auto-import).

## Behavior
- If `auto_import = true` and the login already exists, it is adopted into state.
- If `sid` is provided and does not match the existing login, creation fails with a clear error.

## Testing
- `CGO_ENABLED=0 ci/run_acceptance.sh`
